### PR TITLE
Added Paintbrush/Photograph Scripts

### DIFF
--- a/Assets/Scripts/UI/InventorySelection.cs
+++ b/Assets/Scripts/UI/InventorySelection.cs
@@ -44,6 +44,18 @@ public class InventorySelection : MonoBehaviour
             return;
         }
 
+        if (slotIndex == 1 && !GameManager.Instance.hasPhotograph)
+        {
+            for (int i = 0; i < inventorySlots.Length; i++)
+            {
+                inventorySlots[i].color = defaultColor;
+            }
+            inventorySlots[slotIndex].color = selectedColor;
+            selectedSlot = slotIndex;
+            inventoryEquipper.EquipItem(3);
+            return;
+        }
+
         for (int i = 0; i < inventorySlots.Length; i++)
         {
             inventorySlots[i].color = defaultColor;

--- a/Assets/Scripts/World/GameManager.cs
+++ b/Assets/Scripts/World/GameManager.cs
@@ -7,7 +7,9 @@ public class GameManager : MonoBehaviour
     public static GameManager Instance { get; private set; }
 
     public static bool inMenu = false; // Flag to check if the player is in the menu or not
-    public bool hasPaintbrush = false; // Track if the player has picked up the paintbrush
+    public bool hasPaintbrush = false; // Track if the player has picked up the paintbrush;
+    public bool hasPhotograph = false; // Track if the player has picked up the photograph
+
 
     private FirstPerson playerCamera;
     void Awake() {

--- a/Assets/Scripts/World/Interaction Scripts/PaintbrushInteract.cs
+++ b/Assets/Scripts/World/Interaction Scripts/PaintbrushInteract.cs
@@ -6,7 +6,46 @@ public class PaintbrushInteract : ObjectInteract
 {
     [SerializeField] private GameObject uiElement; // Assign in Inspector
     [SerializeField] private GameObject objectToEnable; // Assign in Inspector
+    [SerializeField] private GameObject uiToDisable; // Assign in Inspector
     public InventorySelection inventorySelection; // Assign in Inspector
+
+    [SerializeField] private GameObject rotationTarget;
+    [SerializeField] private float floatSpeed = 1.0f; // Speed of floating motion
+    [SerializeField] private float floatAmplitude = 0.2f; // Amplitude (height variation)
+    [SerializeField] private float rotationSpeed = 50f; // Speed of Y-axis rotation
+
+    private Vector3 startPosition;
+
+    void Start()
+    {
+        startPosition = transform.position; // Store the initial position
+
+        // If rotationTarget is assigned, use its position as the base floating position
+        if (rotationTarget != null)
+        {
+            startPosition = rotationTarget.transform.position;
+        }
+    }
+
+    void Update()
+    {
+        // Make the object float up and down using sine wave
+        float newY = startPosition.y + Mathf.Sin(Time.time * floatSpeed) * floatAmplitude;
+        transform.position = new Vector3(startPosition.x, newY, startPosition.z);
+
+        // Rotate around the Y-axis
+        if (rotationTarget != null)
+        {
+            rotationTarget.transform.position = new Vector3(startPosition.x, newY, startPosition.z);
+            rotationTarget.transform.Rotate(Vector3.up * rotationSpeed * Time.deltaTime); // Rotate assigned object
+        }
+        else
+        {
+            transform.position = new Vector3(startPosition.x, newY, startPosition.z);
+            transform.Rotate(Vector3.up * rotationSpeed * Time.deltaTime); // Rotate self if no target assigned
+        }
+    }
+
 
     void Awake()
     {
@@ -18,6 +57,13 @@ public class PaintbrushInteract : ObjectInteract
         base.Interact(); // Optional: Call the base method for debug log
         GameManager.Instance.hasPaintbrush = true; // Mark that the player now owns the paintbrush
         uiElement.SetActive(true); // Enable UI
+
+        if (uiToDisable != null)
+        {
+            uiToDisable.SetActive(false); // Disable specified UI element
+        }
+
         inventorySelection.SelectSlot(0); // Select the paintbrush slot
+        gameObject.SetActive(false); // Disable the game object
     }
 }

--- a/Assets/Scripts/World/Interaction Scripts/PhotoInteract.cs
+++ b/Assets/Scripts/World/Interaction Scripts/PhotoInteract.cs
@@ -1,0 +1,27 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PhotoInteract : ObjectInteract
+{
+    [SerializeField] private GameObject uiElement;
+    // Start is called before the first frame update
+    void Start()
+    {
+        
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+
+    public override void Interact()
+    {
+        base.Interact();
+        GameManager.Instance.hasPhotograph = true; // Mark that the player has picked up the photograph
+        uiElement.SetActive(true); // Enable UI element
+        gameObject.SetActive(false); // Hide the object after pickup
+    }
+}

--- a/Assets/Scripts/World/Interaction Scripts/PhotoInteract.cs.meta
+++ b/Assets/Scripts/World/Interaction Scripts/PhotoInteract.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ce5aa9126216f42449da22822269a9d1


### PR DESCRIPTION
Added:
- Paintbrush and Photograph gameObjects
- PhotoInteract.cs
> Sets hasPhotograph bool to true, removes the gameObject then player can select the photograph in the hotbar by pressing "2"
- New text in the UI telling the player to pick up the paintbrush
- PaintbrushInteract.cs
> Added floating and rotations to the paintbrush object. Disables the text telling the player to pick up paintbrush after the player picks up the gameObject

Updated:
- GameManager.cs
> Added new bool to check if player has picked up the photograph
- InventorySelection.cs
> Player pressing 2 won't bring up the photograph if the bool is false